### PR TITLE
Add OSMMakie to Other Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,6 @@ Using the excellent [BinaryBuilder.jl](https://github.com/JuliaPackaging/BinaryB
 #### Other Projects
 - [OpenStreetMapX.jl](https://github.com/pszufe/OpenStreetMapX.jl) provides basic functionality for parsing, viewing, and working with OpenStreetMap map data.
 - [LasIO.jl](https://github.com/visr/LasIO.jl) is native Julia package for working with .las pointcloud data. [LazIO.jl](https://github.com/evetion/LazIO.jl) does the same for compressed .laz pointcloud data.
+- [OSMMakie.jl](https://github.com/fbanning/OSMMakie.jl) is a [Makie.jl](https://makie.juliaplots.org/stable/) recipe for plotting OpenStreetMap data. It works on top of [LightOSM.jl](https://github.com/DeloitteDigitalAPAC/LightOSM.jl) and currently provides basic functionality to plot all kinds of ways and buildings.
 
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Using the excellent [BinaryBuilder.jl](https://github.com/JuliaPackaging/BinaryB
 #### Other Projects
 - [OpenStreetMapX.jl](https://github.com/pszufe/OpenStreetMapX.jl) provides basic functionality for parsing, viewing, and working with OpenStreetMap map data.
 - [LasIO.jl](https://github.com/visr/LasIO.jl) is native Julia package for working with .las pointcloud data. [LazIO.jl](https://github.com/evetion/LazIO.jl) does the same for compressed .laz pointcloud data.
+- [GeoMakie.jl](https://github.com/JuliaPlots/GeoMakie.jl) adds cartography to the [Makie.jl](https://makie.juliaplots.org/stable/) plotting package.
 - [OSMMakie.jl](https://github.com/fbanning/OSMMakie.jl) is a [Makie.jl](https://makie.juliaplots.org/stable/) recipe for plotting OpenStreetMap data. It works on top of [LightOSM.jl](https://github.com/DeloitteDigitalAPAC/LightOSM.jl) and currently provides basic functionality to plot all kinds of ways and buildings.
 
 


### PR DESCRIPTION
Hi JuliaGeo team,

I'm the founder/maintainer of [OSMMakie.jl](https://github.com/fbanning/OSMMakie.jl), a Makie.jl recipe for plotting OpenStreetMap data. I would like to ask you if it's possible to add the project to the JuliaGeo website. OSMMakie is still very heavy WIP but its basic functionality is already there and usable.

This PR would add OSMMakie to the list of "Other Projects". I've located it there because OpenStreetMapX is also there. However, I'm not totally sure if you want plotting libraries in your list or if your organisation is only concerned about downloading/parsing/handling geo data because that's not what OSMMakie does (it relies on LightOSM.jl for that).

Happy to hear your thoughts on this.
Best wishes